### PR TITLE
deleted status text

### DIFF
--- a/DLivr/src/app/pages/mypackages/mypackages.page.html
+++ b/DLivr/src/app/pages/mypackages/mypackages.page.html
@@ -22,7 +22,7 @@
               </ion-card-header>
 
               <ion-card-content>
-                Status: {{package.status}}
+                Status: {{package.status}} ***status
               </ion-card-content>
             </ion-label>
 
@@ -89,9 +89,9 @@
                   </ion-item>
                 </ion-card>-->
   
-                <div id ="text">
+               <!-- <div id ="text">
                   <p> ***(waiting for pickup / picked up / delivering / delivered / canceled / reported) </p>
-                </div>
+                </div>-->
 
       </ion-col>
     </ion-row>


### PR DESCRIPTION
Deleted the status text because when you add a package , it will have a name and a status. So no need for "***(waiting for pickup / picked up / delivering / delivered / canceled / reported) " at the end of page. 